### PR TITLE
Fix school coordinates decimal points

### DIFF
--- a/data/schools.csv
+++ b/data/schools.csv
@@ -1,34 +1,34 @@
 address,fax,fullTimeSchool,id,lat,lon,name,official_id,phone,schoolType,schoolTypeEntity,state,districtNumber,schoolId
-Hauptstraße 22 14476 Potsdam/OT Marquardt,033208 20188,FALSE,BB-106460,52.460.876,12.963.584,Neue Grundschule Marquardt anerkannte Ersatzschule,106460,033208 20187,Grundschule,,BB,A06,Neue+Grundschule+Marquardt+anerkannte+Ersatzschule
-Sternstraße 68 14480 Potsdam,0331 6009305,FALSE,BB-106306,52.364.054,13.127.897,Schiller Grundschule im Sternfeld anerkannte Ersatzschule,106306,0331 6009301,Grundschule,,BB,A01,Schiller+Grundschule+im+Sternfeld+anerkannte+Ersatzschule
-Flotowstraße 10 14480 Potsdam,0331 2011049,FALSE,BB-106124,52.382.314,13.136.734,Neue Grundschule Potsdam anerkannte Ersatzschule,106124,0331 20029766,Grundschule,,BB,A02,Neue+Grundschule+Potsdam+anerkannte+Ersatzschule
-Espengrund 10 14482 Potsdam,,FALSE,BB-106586,52.395.952,13.114.308,Katholische Marienschule Potsdam Grundschule - anerkannte Ersatzschule,106586,0331 60037130,Grundschule,,BB,,Katholische+Marienschule+Potsdam+Grundschule+-+anerkannte+Ersatzschule
-Ravensbergweg 30 14478 Potsdam,0331 88739428,FALSE,BB-106446,52.372.681,13.079.388,Internationale Grundschule Potsdam Primary School genehmigte Ersatzschule,106446,0331 8873550,Grundschule,,BB,A08,Internationale+Grundschule+Potsdam+Primary+School+genehmigte+Ersatzschule
-Bisamkiez 28 14478 Potsdam,0331 8714813,FALSE,BB-106010,52.376.098,13.100.796,Freie Schule Potsdam des Vereins Freie Schule Potsdam e.V.,106010,0331 8714810,Grundschule,,BB,A03,Freie+Schule+Potsdam+des+Vereins+Freie+Schule+Potsdam+e.V.
-Rudolf-Breitscheid-Straße 21 14482 Potsdam,0331 7309316,FALSE,BB-106471,52.392.174,13.090.328,Evangelische Grundschule Potsdam-Babelsberg -anerkannte Ersatzschule,106471,0331 7309314,Grundschule,,BB,,Evangelische+Grundschule+Potsdam-Babelsberg+-anerkannte+Ersatzschule
-Große Weinmeisterstraße 49 14469 Potsdam,0331 2803666,FALSE,BB-106045,52.415.616,13.063.331,Evangelische Grundschule Potsdam,106045,0331 2803660,Grundschule,,BB,A04,Evangelische+Grundschule+Potsdam
-Kaiser-Friedrich-Straße 32 14469 Potsdam,0331 7304071,FALSE,BB-106732,52.404.877,12.988.227,"AWO Grundschule ""Marie Juchacz"" Potsdam - genehmigte Ersatzschule",106732,0171 8182464,Grundschule,,BB,,AWO+Grundschule+Marie+Juchacz+Potsdam+-+genehmigte+Ersatzschule
-Liefeldsgrund 23-25 14478 Potsdam,0331 2733039,FALSE,BB-106320,5.235.943,1.309.365,Aktive Schule Potsdam Grundschule,106320,0331 2733034,Grundschule,,BB,A07,Aktive+Schule+Potsdam+Grundschule
-Hechtsprung 14 14476 Potsdam/OT Groß Glienicke,033201 20415,FALSE,BB-103512,52.466.012,13.104.282,"Grundschule ""Hanna von Pestalozza"" ",103512,033201 20414,Grundschule,,BB,6,Grundschule+Hanna+von+Pestalozza
-Ketziner Straße 31c 14476 Potsdam/OT Fahrland,033208 217874,FALSE,BB-112082,52.471.927,13.004.958,Regenbogenschule Fahrland,112082,033208 50260,Grundschule,,BB,7,Regenbogenschule+Fahrland
-Haeckelstraße 74 14471 Potsdam,0331 2897521,FALSE,BB-105429,52.389.277,13.022.926,Zeppelin-Grundschule,105429,0331 2897520,Grundschule,,BB,23,Zeppelin-Grundschule
-Schilfhof 29 14478 Potsdam,0331 2897281,FALSE,BB-105351,52.378.114,13.097.016,Weidenhof-Grundschule,105351,0331 2897280,Grundschule,,BB,40,Weidenhof-Grundschule
-Friedrich-Wolf-Straße 12 14478 Potsdam,0331 2897631,FALSE,BB-105430,52.367.526,13.096.144,Waldstadt-Grundschule,105430,0331 2897630,Grundschule,,BB,27,Waldstadt-Grundschule
-Domstraße 14b 14482 Potsdam,0331 2897651,FALSE,BB-112999,52.396.103,13.116.227,Schule am Griebnitzsee,112999,0331 2897650,Grundschule,,BB,33,Schule+am+Griebnitzsee
-Burgstraße 23a 14467 Potsdam,0331 2897951,FALSE,BB-105454,52.397.313,13.066.928,Rosa-Luxemburg-Schule,105454,0331 2897950,Grundschule,,BB,19,Rosa-Luxemburg-Schule
-Zum Teufelssee 2-4 14478 Potsdam,0331 2898131,FALSE,BB-113001,5.236.041,13.091.496,"Oberschule ""Theodor Fontane"" mit Primarstufe",113001,0331 2898130,Oberschule mit Grundschule,,BB,,Oberschule+Theodor+Fontane+mit+Primarstufe
-Schlüterstraße 2 14471 Potsdam,0331 2898061,FALSE,BB-112963,52.388.863,13.013.365,Montessori-Oberschule mit Primarstufe,112963,0331 2898060,Oberschule mit Grundschule,,BB,,Montessori-Oberschule+mit+Primarstufe
-Kirschallee 172 14469 Potsdam,0331 2897601,FALSE,BB-112938,52.415.626,13.033.699,Karl-Foerster-Schule Städtische Grundschule Potsdam,112938,0331 2897600,Grundschule,,BB,25/26,Karl-Foerster-Schule+St%C3%A4dtische+Grundschule+Potsdam
-Lise-Meitner-Straße 4-6 14480 Potsdam,0331 2897801,FALSE,BB-106008,52.359.701,13.136.927,Grundschule Im Kirchsteigfeld,106008,0331 2897800,Grundschule,,BB,56,Grundschule+Im+Kirchsteigfeld
-Jakob-von-Gundling-Straße 25 14469 Potsdam,0331 2894531,FALSE,BB-106677,52.411.451,13.046.629,Grundschule im Bornstedter Feld,106677,0331 2894530,Grundschule,,BB,,Grundschule+im+Bornstedter+Feld
-Potsdamer Straße 90 14469 Potsdam,0331 2896201,FALSE,BB-106720,52.422.374,13.002.744,Grundschule Bornim,106720,0331 2896200,Grundschule,,BB,,Grundschule+Bornim
-Galileistraße 8 14480 Potsdam,0331 2897721,FALSE,BB-105363,52.375.921,13.134.456,Grundschule Am Pappelhain,105363,0331 2897720,Grundschule,,BB,36/45,Grundschule+Am+Pappelhain
-Humboldtring 15-17 14473 Potsdam,0331 2897761,FALSE,BB-105405,523.964.728,13.076.753,Grundschule am Humboldtring,105405,0331 2897760,Grundschule,,BB,37,Grundschule+am+Humboldtring
-Dortustraße 28-29 14467 Potsdam,0331 2897441,FALSE,BB-105326,523.978.441,130.530.114,"Grundschule ""Max Dortu"" ",105326,0331 2897440,Grundschule,,BB,8,Grundschule+Max+Dortu
-Kaiser-Friedrich-Straße 15a 14469 Potsdam,0331 2897401,FALSE,BB-103421,52.405.351,12.993.501,"Grundschule ""Ludwig Renn"" ",103421,0331 2897400,Grundschule,,BB,2,Grundschule+Ludwig+Renn
-Karl-Liebknecht-Straße 29 14482 Potsdam,0331 2897481,FALSE,BB-105491,52.395.381,1.309.389,"Grundschule ""Bruno H. Bürgel"" ",105491,0331 2897480,Grundschule,,BB,16,Grundschule+Bruno+H.+B%C3%BCrgel
-Oskar-Meßter-Straße 4-6 14480 Potsdam,0331 2897501,FALSE,BB-105466,52.366.156,1.313.457,"Grundschule ""Am Priesterweg"" ",105466,0331 2897500,Grundschule,,BB,20,Grundschule+Am+Priesterweg
-Esplanade 5 14469 Potsdam,,FALSE,BB-106770,52.4,1.306.667,Grundschule im Bornstedter Feld - Rote Kaserne Ost,106770,0331 2896250,Grundschule,,BB,,Grundschule+im+Bornstedter+Feld+-+Rote+Kaserne+Ost
-Stephensonstraße 1 14482 Potsdam,0331 2898051,FALSE,BB-106653,52.390.422,13.099.345,Goethe-Grundschule,106653,0331 2898050,Grundschule,,BB,31,Goethe-Grundschule
-Carl-von-Ossietzky-Straße 37 14471 Potsdam,0331 2897461,FALSE,BB-105478,52.394.267,13.034.207,Gerhart-Hauptmann-Grundschule Potsdam,105478,0331 2897460,Grundschule,,BB,12,Gerhart-Hauptmann-Grundschule+Potsdam
-Kurfürstenstraße 51 14467 Potsdam,0331 2897561,FALSE,BB-105533,52.404.226,13.061.542,Eisenhart-Schule,105533,0331 2897560,Grundschule,,BB,24,Eisenhart-Schule
+Hauptstraße 22 14476 Potsdam/OT Marquardt,033208 20188,FALSE,BB-106460,52.460876,12.963584,Neue Grundschule Marquardt anerkannte Ersatzschule,106460,033208 20187,Grundschule,,BB,A06,Neue+Grundschule+Marquardt+anerkannte+Ersatzschule
+Sternstraße 68 14480 Potsdam,0331 6009305,FALSE,BB-106306,52.364054,13.127897,Schiller Grundschule im Sternfeld anerkannte Ersatzschule,106306,0331 6009301,Grundschule,,BB,A01,Schiller+Grundschule+im+Sternfeld+anerkannte+Ersatzschule
+Flotowstraße 10 14480 Potsdam,0331 2011049,FALSE,BB-106124,52.382314,13.136734,Neue Grundschule Potsdam anerkannte Ersatzschule,106124,0331 20029766,Grundschule,,BB,A02,Neue+Grundschule+Potsdam+anerkannte+Ersatzschule
+Espengrund 10 14482 Potsdam,,FALSE,BB-106586,52.395952,13.114308,Katholische Marienschule Potsdam Grundschule - anerkannte Ersatzschule,106586,0331 60037130,Grundschule,,BB,,Katholische+Marienschule+Potsdam+Grundschule+-+anerkannte+Ersatzschule
+Ravensbergweg 30 14478 Potsdam,0331 88739428,FALSE,BB-106446,52.372681,13.079388,Internationale Grundschule Potsdam Primary School genehmigte Ersatzschule,106446,0331 8873550,Grundschule,,BB,A08,Internationale+Grundschule+Potsdam+Primary+School+genehmigte+Ersatzschule
+Bisamkiez 28 14478 Potsdam,0331 8714813,FALSE,BB-106010,52.376098,13.100796,Freie Schule Potsdam des Vereins Freie Schule Potsdam e.V.,106010,0331 8714810,Grundschule,,BB,A03,Freie+Schule+Potsdam+des+Vereins+Freie+Schule+Potsdam+e.V.
+Rudolf-Breitscheid-Straße 21 14482 Potsdam,0331 7309316,FALSE,BB-106471,52.392174,13.090328,Evangelische Grundschule Potsdam-Babelsberg -anerkannte Ersatzschule,106471,0331 7309314,Grundschule,,BB,,Evangelische+Grundschule+Potsdam-Babelsberg+-anerkannte+Ersatzschule
+Große Weinmeisterstraße 49 14469 Potsdam,0331 2803666,FALSE,BB-106045,52.415616,13.063331,Evangelische Grundschule Potsdam,106045,0331 2803660,Grundschule,,BB,A04,Evangelische+Grundschule+Potsdam
+Kaiser-Friedrich-Straße 32 14469 Potsdam,0331 7304071,FALSE,BB-106732,52.404877,12.988227,"AWO Grundschule ""Marie Juchacz"" Potsdam - genehmigte Ersatzschule",106732,0171 8182464,Grundschule,,BB,,AWO+Grundschule+Marie+Juchacz+Potsdam+-+genehmigte+Ersatzschule
+Liefeldsgrund 23-25 14478 Potsdam,0331 2733039,FALSE,BB-106320,52.35943,13.09365,Aktive Schule Potsdam Grundschule,106320,0331 2733034,Grundschule,,BB,A07,Aktive+Schule+Potsdam+Grundschule
+Hechtsprung 14 14476 Potsdam/OT Groß Glienicke,033201 20415,FALSE,BB-103512,52.466012,13.104282,"Grundschule ""Hanna von Pestalozza"" ",103512,033201 20414,Grundschule,,BB,6,Grundschule+Hanna+von+Pestalozza
+Ketziner Straße 31c 14476 Potsdam/OT Fahrland,033208 217874,FALSE,BB-112082,52.471927,13.004958,Regenbogenschule Fahrland,112082,033208 50260,Grundschule,,BB,7,Regenbogenschule+Fahrland
+Haeckelstraße 74 14471 Potsdam,0331 2897521,FALSE,BB-105429,52.389277,13.022926,Zeppelin-Grundschule,105429,0331 2897520,Grundschule,,BB,23,Zeppelin-Grundschule
+Schilfhof 29 14478 Potsdam,0331 2897281,FALSE,BB-105351,52.378114,13.097016,Weidenhof-Grundschule,105351,0331 2897280,Grundschule,,BB,40,Weidenhof-Grundschule
+Friedrich-Wolf-Straße 12 14478 Potsdam,0331 2897631,FALSE,BB-105430,52.367526,13.096144,Waldstadt-Grundschule,105430,0331 2897630,Grundschule,,BB,27,Waldstadt-Grundschule
+Domstraße 14b 14482 Potsdam,0331 2897651,FALSE,BB-112999,52.396103,13.116227,Schule am Griebnitzsee,112999,0331 2897650,Grundschule,,BB,33,Schule+am+Griebnitzsee
+Burgstraße 23a 14467 Potsdam,0331 2897951,FALSE,BB-105454,52.397313,13.066928,Rosa-Luxemburg-Schule,105454,0331 2897950,Grundschule,,BB,19,Rosa-Luxemburg-Schule
+Zum Teufelssee 2-4 14478 Potsdam,0331 2898131,FALSE,BB-113001,52.36041,13.091496,"Oberschule ""Theodor Fontane"" mit Primarstufe",113001,0331 2898130,Oberschule mit Grundschule,,BB,,Oberschule+Theodor+Fontane+mit+Primarstufe
+Schlüterstraße 2 14471 Potsdam,0331 2898061,FALSE,BB-112963,52.388863,13.013365,Montessori-Oberschule mit Primarstufe,112963,0331 2898060,Oberschule mit Grundschule,,BB,,Montessori-Oberschule+mit+Primarstufe
+Kirschallee 172 14469 Potsdam,0331 2897601,FALSE,BB-112938,52.415626,13.033699,Karl-Foerster-Schule Städtische Grundschule Potsdam,112938,0331 2897600,Grundschule,,BB,25/26,Karl-Foerster-Schule+St%C3%A4dtische+Grundschule+Potsdam
+Lise-Meitner-Straße 4-6 14480 Potsdam,0331 2897801,FALSE,BB-106008,52.359701,13.136927,Grundschule Im Kirchsteigfeld,106008,0331 2897800,Grundschule,,BB,56,Grundschule+Im+Kirchsteigfeld
+Jakob-von-Gundling-Straße 25 14469 Potsdam,0331 2894531,FALSE,BB-106677,52.411451,13.046629,Grundschule im Bornstedter Feld,106677,0331 2894530,Grundschule,,BB,,Grundschule+im+Bornstedter+Feld
+Potsdamer Straße 90 14469 Potsdam,0331 2896201,FALSE,BB-106720,52.422374,13.002744,Grundschule Bornim,106720,0331 2896200,Grundschule,,BB,,Grundschule+Bornim
+Galileistraße 8 14480 Potsdam,0331 2897721,FALSE,BB-105363,52.375921,13.134456,Grundschule Am Pappelhain,105363,0331 2897720,Grundschule,,BB,36/45,Grundschule+Am+Pappelhain
+Humboldtring 15-17 14473 Potsdam,0331 2897761,FALSE,BB-105405,52.3964728,13.076753,Grundschule am Humboldtring,105405,0331 2897760,Grundschule,,BB,37,Grundschule+am+Humboldtring
+Dortustraße 28-29 14467 Potsdam,0331 2897441,FALSE,BB-105326,52.3978441,13.0530114,"Grundschule ""Max Dortu"" ",105326,0331 2897440,Grundschule,,BB,8,Grundschule+Max+Dortu
+Kaiser-Friedrich-Straße 15a 14469 Potsdam,0331 2897401,FALSE,BB-103421,52.405351,12.993501,"Grundschule ""Ludwig Renn"" ",103421,0331 2897400,Grundschule,,BB,2,Grundschule+Ludwig+Renn
+Karl-Liebknecht-Straße 29 14482 Potsdam,0331 2897481,FALSE,BB-105491,52.395381,13.09389,"Grundschule ""Bruno H. Bürgel"" ",105491,0331 2897480,Grundschule,,BB,16,Grundschule+Bruno+H.+B%C3%BCrgel
+Oskar-Meßter-Straße 4-6 14480 Potsdam,0331 2897501,FALSE,BB-105466,52.366156,13.13457,"Grundschule ""Am Priesterweg"" ",105466,0331 2897500,Grundschule,,BB,20,Grundschule+Am+Priesterweg
+Esplanade 5 14469 Potsdam,,FALSE,BB-106770,52.4,13.06667,Grundschule im Bornstedter Feld - Rote Kaserne Ost,106770,0331 2896250,Grundschule,,BB,,Grundschule+im+Bornstedter+Feld+-+Rote+Kaserne+Ost
+Stephensonstraße 1 14482 Potsdam,0331 2898051,FALSE,BB-106653,52.390422,13.099345,Goethe-Grundschule,106653,0331 2898050,Grundschule,,BB,31,Goethe-Grundschule
+Carl-von-Ossietzky-Straße 37 14471 Potsdam,0331 2897461,FALSE,BB-105478,52.394267,13.034207,Gerhart-Hauptmann-Grundschule Potsdam,105478,0331 2897460,Grundschule,,BB,12,Gerhart-Hauptmann-Grundschule+Potsdam
+Kurfürstenstraße 51 14467 Potsdam,0331 2897561,FALSE,BB-105533,52.404226,13.061542,Eisenhart-Schule,105533,0331 2897560,Grundschule,,BB,24,Eisenhart-Schule


### PR DESCRIPTION
Decimal coordinates looked misformatted like some export went wrong.

Fix decimal points from e.g. 523.964.728 to 52.3964728.

The actual coordinates were not checked, but at least are in a plausible
range now.